### PR TITLE
Change demonic altar item model transformations

### DIFF
--- a/src/generated/resources/assets/arcanerituals/models/item/demonic_altar.json
+++ b/src/generated/resources/assets/arcanerituals/models/item/demonic_altar.json
@@ -1,3 +1,87 @@
 {
-  "parent": "arcanerituals:block/demonic_altar_v2"
+  "parent": "arcanerituals:block/demonic_altar_v2",
+  "display": {
+    "gui": {
+      "rotation": [
+        22.5,
+        45,
+        0
+      ],
+      "scale": [
+        0.6,
+        0.6,
+        0.6
+      ]
+    },
+    "firstperson_lefthand": {
+      "rotation": [
+        0,
+        45,
+        0
+      ],
+      "scale": [
+        0.5,
+        0.5,
+        0.5
+      ]
+    },
+    "firstperson_righthand": {
+      "rotation": [
+        0,
+        45,
+        0
+      ],
+      "scale": [
+        0.5,
+        0.5,
+        0.5
+      ]
+    },
+    "ground": {
+      "translation": [
+        0,
+        3,
+        0
+      ],
+      "scale": [
+        0.3,
+        0.3,
+        0.3
+      ]
+    },
+    "thirdperson_lefthand": {
+      "rotation": [
+        67.5,
+        45,
+        0
+      ],
+      "translation": [
+        0,
+        3,
+        1
+      ],
+      "scale": [
+        0.4,
+        0.4,
+        0.4
+      ]
+    },
+    "thirdperson_righthand": {
+      "rotation": [
+        67.5,
+        45,
+        0
+      ],
+      "translation": [
+        0,
+        3,
+        1
+      ],
+      "scale": [
+        0.4,
+        0.4,
+        0.4
+      ]
+    }
+  }
 }

--- a/src/generated/resources/data/arcanerituals/advancements/recipes/arcane_rituals/vial.json
+++ b/src/generated/resources/data/arcanerituals/advancements/recipes/arcane_rituals/vial.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "arcanerituals:vial"
+    ]
+  },
+  "criteria": {
+    "has_glass": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:glass"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "arcanerituals:vial"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_glass",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/arcanerituals/recipes/vial.json
+++ b/src/generated/resources/data/arcanerituals/recipes/vial.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "C ",
+    "G "
+  ],
+  "key": {
+    "C": {
+      "item": "minecraft:clay_ball"
+    },
+    "G": {
+      "item": "minecraft:glass"
+    }
+  },
+  "result": {
+    "item": "arcanerituals:vial",
+    "count": 2
+  }
+}

--- a/src/main/java/com/dpeter99/arcanerituals/ArcaneRituals.java
+++ b/src/main/java/com/dpeter99/arcanerituals/ArcaneRituals.java
@@ -2,10 +2,11 @@ package com.dpeter99.arcanerituals;
 
 import com.dpeter99.arcanerituals.registry.ARRegistry;
 import com.dpeter99.arcanerituals.registry.mobblood.MobBloodManager;
-import com.dpeter99.bloodylib.TestKt;
+//import com.dpeter99.bloodylib.TestKt;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.InterModComms;
@@ -31,7 +32,7 @@ public class ArcaneRituals {
 
         MinecraftForge.EVENT_BUS.register(this);
 
-        LOGGER.error(TestKt.INSTANCE.getTEST());
+        //LOGGER.error(TestKt.INSTANCE.getTEST());
 
 
     }

--- a/src/main/java/com/dpeter99/arcanerituals/datagen/item/ItemModelProviders.java
+++ b/src/main/java/com/dpeter99/arcanerituals/datagen/item/ItemModelProviders.java
@@ -4,6 +4,7 @@ import com.dpeter99.arcanerituals.ArcaneRituals;
 import com.dpeter99.arcanerituals.registry.ARRegistry;
 import net.minecraft.data.DataGenerator;
 import net.minecraftforge.client.model.generators.ItemModelProvider;
+import net.minecraftforge.client.model.generators.ModelBuilder.Perspective;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.fml.RegistryObject;
 
@@ -16,9 +17,7 @@ public class ItemModelProviders extends ItemModelProvider {
     @Override
     protected void registerModels() {
         // Altar Item
-        String vanillaExplosive = ARRegistry.getName(ARRegistry.DEMONIC_ALTAR_ITEM).getPath();
-
-        withExistingParent(vanillaExplosive, modLoc("block/demonic_altar_v2"));
+        demonicAltar();
 
         //Sacraficial knife
 
@@ -31,6 +30,18 @@ public class ItemModelProviders extends ItemModelProvider {
         generatedItem(ARRegistry.HAMMER);
         generatedItem(ARRegistry.IRON_RING);
 
+    }
+
+    private void demonicAltar() {
+        String name = ARRegistry.getName(ARRegistry.DEMONIC_ALTAR_ITEM).getPath();
+
+        withExistingParent(name, modLoc("block/demonic_altar_v2")).transforms().transform(Perspective.GUI)
+                .rotation(22.5f, 45, 0).scale(0.6f).end().transform(Perspective.FIRSTPERSON_LEFT).scale(0.5f)
+                .rotation(0, 45, 0).end().transform(Perspective.FIRSTPERSON_RIGHT).scale(0.5f).rotation(0, 45, 0).end()
+                .transform(Perspective.GROUND).scale(0.3f).translation(0, 3, 0).end()
+                .transform(Perspective.THIRDPERSON_LEFT).scale(0.4f).rotation(67.5f, 45, 0).translation(0, 3, 1).end()
+                .transform(Perspective.THIRDPERSON_RIGHT).scale(0.4f).rotation(67.5f, 45, 0).translation(0, 3, 1).end()
+                .end();
     }
 
     public void generatedItem(RegistryObject<?> a){

--- a/src/main/java/com/dpeter99/arcanerituals/registry/ARRegistry.java
+++ b/src/main/java/com/dpeter99/arcanerituals/registry/ARRegistry.java
@@ -1,5 +1,8 @@
 package com.dpeter99.arcanerituals.registry;
 
+import java.util.Objects;
+import java.util.function.Supplier;
+
 import com.dpeter99.arcanerituals.ArcaneRituals;
 import com.dpeter99.arcanerituals.blocks.DemonicAltarBlock;
 import com.dpeter99.arcanerituals.client.renderers.FluidHolderRenderer;

--- a/src/main/java/com/dpeter99/arcanerituals/registry/mobblood/MobBlood.java
+++ b/src/main/java/com/dpeter99/arcanerituals/registry/mobblood/MobBlood.java
@@ -5,6 +5,9 @@ import net.minecraftforge.items.wrapper.RecipeWrapper;
 import net.minecraftforge.registries.IForgeRegistryEntry;
 
 import javax.annotation.Nullable;
+
+import com.dpeter99.arcanerituals.ArcaneRituals;
+
 import java.util.HashMap;
 import java.util.Map;
 


### PR DESCRIPTION
This change updates the item model transformations for the demonic
altar, so that it is similar to how vanilla blocks are scaled and
rotated when held/in gui/on ground.

Also:
* A vial recipe got generated when I ran runData, so that is also added
* Some imports were missing in a few classes, so I added those back so
  that the mod could be compiled
* Commented out kotlin line in ArcaneRituals class